### PR TITLE
ZIPダウンロード後に一時ファイルを削除

### DIFF
--- a/app/Http/Controllers/InfoController.php
+++ b/app/Http/Controllers/InfoController.php
@@ -259,7 +259,7 @@ DCTX;
             }else{
                 abort(500, 'ZIPアーカイブの作成に失敗しました');
             }
-            return response()->download($name, 'assaultlily-dic.zip');
+            return response()->download($name, 'assaultlily-dic.zip')->deleteFileAfterSend(true);
         }
 
         return view('main.imedic', compact('dicString'));


### PR DESCRIPTION
一般的なサーバOSであれば1日1回一時フォルダのクリーンアップが実行されるため放置しても問題ないはずですが、念のため。