### PR TITLE
ラベルの表示位置を変更・中止公演の表示を追加

### DIFF
--- a/resources/views/book/index.blade.php
+++ b/resources/views/book/index.blade.php
@@ -46,8 +46,8 @@ $ogp['description'] = '書籍の一覧を表示します。現在'.count($books)
         @forelse($books as $bookKey => $book)
             <a class="book list-item-b" href="{{ route('book.show', ['book' => str_replace('lilyrdf:','',$bookKey)]) }}">
                 <div class="title">
-                    {{ $book['schema:name'][0] }}
                     @if(!empty($book['lily:genre'][0]))<span class="tag">{{ $book['lily:genre'][0] }}</span>@endif
+                    {{ $book['schema:name'][0] }}
                 </div>
                 <div style="margin: .5em 0">
                     <span class="tag">著者</span> {{ implode(', ',$book['schema:author'] ?? array()) }}

--- a/resources/views/play/index.blade.php
+++ b/resources/views/play/index.blade.php
@@ -21,8 +21,8 @@ $ogp['description'] = '公演の一覧を表示します。現在'.count($plays)
         @forelse($plays as $playKey => $play)
             <a class="book list-item-b" href="{{ route('play.show', ['play' => str_replace('lilyrdf:','',$playKey)]) }}">
                 <div class="title">
-                    {{ $play['schema:name'][0] }}
                     @if(!empty($play['lily:genre'][0]))<span class="tag">{{ $play['lily:genre'][0] }}</span>@endif
+                    {{ $play['schema:name'][0] }}
                 </div>
                 <div style="margin: .5em 0">
                     @if(!empty($play['lily:originalAuthor']))

--- a/resources/views/play/show.blade.php
+++ b/resources/views/play/show.blade.php
@@ -161,7 +161,11 @@ $ogp['description'] = "舞台 ".$play[$ps]['schema:name'][0]." の情報です�
                         <th>公演日時</th>
                         <td rowspan="2">
                             @foreach($play[$ps]['lily:showTime'] as $showTime)
-                                <div style="min-width: 220px;">{{ \Carbon\Carbon::make($showTime)->isoFormat('YYYY年M月D日 (ddd) HH:mm') }}</div>
+                                @if(in_array($showTime, $play[$ps]['lily:cancelledShowTime'] ?? [], true))
+                                    <div style="min-width: 220px;"><s>{{ \Carbon\Carbon::make($showTime)->isoFormat('YYYY年M月D日 (ddd) HH:mm') }}</s> 中止</div>
+                                @else
+                                    <div style="min-width: 220px;">{{ \Carbon\Carbon::make($showTime)->isoFormat('YYYY年M月D日 (ddd) HH:mm') }}</div>
+                                @endif
                             @endforeach
                         </td>
                     </tr>


### PR DESCRIPTION
- 「舞台」「小説」などのラベルの表示位置をタイトル末尾から先頭に変更
- 中止になった公演の公演日時に取消線と「中止」の表示を追加

← before : after →
<img src="https://user-images.githubusercontent.com/8458066/151106407-62a5a610-357a-4078-9425-ba071dac083c.png" width="400"> <img src="https://user-images.githubusercontent.com/8458066/151106524-631b187d-fd75-48ff-8c3b-2ab54e1986df.png" width="400">

<img src="https://user-images.githubusercontent.com/8458066/151106735-d164e7d3-2caf-4773-80cf-904369902468.png" width="400"> <img src="https://user-images.githubusercontent.com/8458066/151106714-ad844ffb-a0da-40aa-8f4b-ba70cf56bd1a.png" width="400">
